### PR TITLE
File path input

### DIFF
--- a/apollyon.py
+++ b/apollyon.py
@@ -133,7 +133,7 @@ execute("exec(__import__('apollyon').decode(script, key))")
 
 
 
-file = input(f"{Col.Symbol('?', Col.orange, Col.red)} {Col.orange}Drag a file to obfuscate {Col.red}-> {Col.reset}")
+file = input(f"{Col.Symbol('?', Col.orange, Col.red)} {Col.orange}Drag a file to obfuscate {Col.red}-> {Col.reset}").replace('\\ ', ' ').strip()
 
 print()
 


### PR DESCRIPTION
Updated:
- Added `.replace('\\ ', ' ').strip()` to the end of the input asking for a file to be dragged and dropped into the terminal.
> This bit of code removes the empty space at the end of the path after dragging and dropping a file into the terminal. So you can literally just drag, drop, and go without it screaming about it not being a file and doesn't exist.